### PR TITLE
Add name field to object struct

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: rust
 script:
   - cargo build -v
   - cargo doc -v
+  - cargo test -v
 after_success:
   - curl http://docs.piston.rs/travis-doc-upload.sh | sh

--- a/src/document.rs
+++ b/src/document.rs
@@ -318,6 +318,7 @@ impl ColladaDocument {
 
     fn get_object(&self, geometry_element: &xml::Element) -> Option<Object> {
         let id = try_some!(geometry_element.get_attribute("id", None));
+        let name = try_some!(geometry_element.get_attribute("name", None));
         let mesh_element = try_some!(geometry_element.get_child("mesh", self.get_ns()));
         let shapes = try_some!(self.get_shapes(mesh_element));
         let binding_type = try_some!(self.get_geometry_binding_type(mesh_element));
@@ -404,7 +405,8 @@ impl ColladaDocument {
         };
 
         Some(Object {
-            name: id.to_string(),
+            id: id.to_string(),
+            name: name.to_string(),
             vertices: positions,
             tex_vertices: texcoords,
             normals: normals,

--- a/src/document.rs
+++ b/src/document.rs
@@ -585,7 +585,8 @@ fn test_get_obj_set() {
     assert_eq!(obj_set.objects.len(), 1);
 
     let ref object = obj_set.objects[0];
-    assert_eq!(object.name, "BoxyWorm-mesh");
+    assert_eq!(object.id, "BoxyWorm-mesh");
+    assert_eq!(object.name, "BoxyWorm");
     assert_eq!(object.vertices.len(), 16);
     assert_eq!(object.tex_vertices.len(), 84);
     assert_eq!(object.normals.len(), 28);
@@ -611,7 +612,8 @@ fn test_get_obj_set_triangles_geometry() {
     assert_eq!(obj_set.objects.len(), 1);
 
     let ref object = obj_set.objects[0];
-    assert_eq!(object.name, "Cube-mesh");
+    assert_eq!(object.id, "Cube-mesh");
+    assert_eq!(object.name, "Cube");
     assert_eq!(object.vertices.len(), 8);
     assert_eq!(object.normals.len(), 12);
     assert_eq!(object.geometry.len(), 1);

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -13,6 +13,7 @@ pub struct ObjSet {
 /// A mesh object.
 #[derive(Clone, Debug)]
 pub struct Object {
+  pub id: String,
   /// A human-readable name for this object. This can be set in blender.
   pub name: String,
   /// The set of vertices this object is composed of. These are referenced


### PR DESCRIPTION
This adds a name field (in addition to id) to the `Object` struct so you can access both fields if needed