### PR TITLE
Bugfix for COLLADA files with multiple input sets

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -603,7 +603,13 @@ impl ColladaDocument {
         let p_element = (prim_element.get_child("p", self.get_ns()))?;
         let indices: Vec<usize> = (get_array_content(p_element))?;
 
-        let input_count = prim_element.get_children("input", self.get_ns()).count();
+        let input_count = prim_element.get_children("input", self.get_ns())
+          .filter(|c| if let Some(set) = c.get_attribute("set", None) {
+            return set == "0"
+          } else {
+            true
+          })
+          .count();
 
         let position_offset = (self.get_input_offset(prim_element, "VERTEX"))?;
 

--- a/test_assets/test.dae
+++ b/test_assets/test.dae
@@ -76,6 +76,15 @@
             </accessor>
           </technique_common>
         </source>
+        <source id="BoxyWorm-mesh-map-1">
+          <float_array id="BoxyWorm-mesh-map-1-array" count="168">0 0 1 0 1 1 0 0 1 0 1 1 1 0 1 1 0 1 1 0 1 1 0 1 0 0 1 0 1 1 0 0 1 0 1 1 0 0 1 0 1 1 0 0 1 0 1 1 0 0 1 0 1 1 0 0 1 0 1 1 1 0 1 1 0 1 0 0 1 0 1 1 0 0 1 0 1 1 0 0 1 0 1 1 0 1 0 0 1 1 0 1 0 0 1 1 0 0 1 0 0 1 0 0 1 0 0 1 0 1 0 0 1 1 0 1 0 0 1 1 0 1 0 0 1 1 0 1 0 0 1 1 0 1 0 0 1 1 0 1 0 0 1 1 0 0 1 0 0 1 0 1 0 0 1 1 0 1 0 0 1 1 0 1 0 0 1 1</float_array>
+          <technique_common>
+            <accessor source="#BoxyWorm-mesh-map-1-array" count="84" stride="2">
+              <param name="S" type="float"/>
+              <param name="T" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
         <source id="BoxyWorm-mesh-colors-Col" name="Col">
           <float_array id="BoxyWorm-mesh-colors-Col-array" count="252">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</float_array>
           <technique_common>
@@ -93,6 +102,7 @@
           <input semantic="VERTEX" source="#BoxyWorm-mesh-vertices" offset="0"/>
           <input semantic="NORMAL" source="#BoxyWorm-mesh-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#BoxyWorm-mesh-map-0" offset="2" set="0"/>
+          <input semantic="TEXCOORD" source="#BoxyWorm-mesh-map-1" offset="2" set="1"/>
           <input semantic="COLOR" source="#BoxyWorm-mesh-colors-Col" offset="3" set="0"/>
           <vcount>3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 </vcount>
           <p>0 0 0 0 1 0 1 1 2 0 2 2 7 1 3 3 6 1 4 4 10 1 5 5 4 2 6 6 5 2 7 7 1 2 8 8 5 3 9 9 6 3 10 10 2 3 11 11 2 4 12 12 6 4 13 13 7 4 14 14 4 5 15 15 0 5 16 16 3 5 17 17 11 6 18 18 10 6 19 19 14 6 20 20 6 7 21 21 5 7 22 22 9 7 23 23 4 8 24 24 7 8 25 25 11 8 26 26 5 9 27 27 4 9 28 28 8 9 29 29 15 10 30 30 14 10 31 31 13 10 32 32 10 11 33 33 9 11 34 34 13 11 35 35 8 12 36 36 11 12 37 37 15 12 38 38 9 13 39 39 8 13 40 40 12 13 41 41 3 14 42 42 0 14 43 43 2 14 44 44 11 15 45 45 7 15 46 46 10 15 47 47 0 16 48 48 4 16 49 49 1 16 50 50 1 17 51 51 5 17 52 52 2 17 53 53 3 18 54 54 2 18 55 55 7 18 56 56 7 19 57 57 4 19 58 58 3 19 59 59 15 20 60 60 11 20 61 61 14 20 62 62 10 21 63 63 6 21 64 64 9 21 65 65 8 22 66 66 4 22 67 67 11 22 68 68 9 23 69 69 5 23 70 70 8 23 71 71 12 24 72 72 15 24 73 73 13 24 74 74 14 25 75 75 10 25 76 76 13 25 77 77 12 26 78 78 8 26 79 79 15 26 80 80 13 27 81 81 9 27 82 82 12 27 83 83</p>


### PR DESCRIPTION
Bugfix for opening COLLADA files that contain multiple input sets (i.e. pointing to the same offset) for a series of triangles. The crash occurs because the `get_vtn_indices` function counts the total number of input nodes, and doesn't support reuse of an offset. For example:

```xml
<input semantic="TEXCOORD" source="#test-mesh-map-0" offset="2" set="0"/>
<input semantic="TEXCOORD" source="#test-mesh-map-1" offset="2" set="1"/>
```

I added a simple test case that tests for this behaviour, and implemented the fix by filtering any additional input sets, before counting the _unique_ indices.