### PR TITLE
Fix newline issue in parse_string_to_vector

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,7 @@ use xml::Xml::{ElementNode, CharacterNode};
 
 pub fn parse_string_to_vector<T: FromStr>(string: &str) -> Vec<T> {
     string.trim()
-        .split(" ")
+        .split(&[' ', '\n'][..])
         .map(|s| s.parse().ok().expect("Error parsing array in COLLADA file"))
         .collect()
 }


### PR DESCRIPTION
This fixes an issue where the parser would fail to parse vectors in a float_array due to the array string not being split on newline characters.

The issue was observed on a DAE file exported from Maya 2019.