### PR TITLE
Change skeleton_name in BindData to Option<String>

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -897,7 +897,7 @@ fn test_get_bind_data_set() {
 
     assert_eq!(bind_data.object_name, "BoxyWorm-mesh");
     assert!(bind_data.skeleton_name.is_some());
-    assert_eq!(bind_data.skeleton_name.unwrap(), "BoxWormRoot");
+    assert_eq!(bind_data.skeleton_name.unwrap().as_str(), "BoxWormRoot");
     assert_eq!(bind_data.joint_names, ["Root", "UpperArm", "LowerArm"]);
     assert_eq!(bind_data.vertex_weights.len(), 29);
     assert_eq!(bind_data.weights.len(), 29);

--- a/src/document.rs
+++ b/src/document.rs
@@ -896,7 +896,7 @@ fn test_get_bind_data_set() {
     let bind_data = &bind_data_set.bind_data[0];
 
     assert_eq!(bind_data.object_name, "BoxyWorm-mesh");
-    assert_eq!(bind_data.skeleton_name.is_some());
+    assert!(bind_data.skeleton_name.is_some());
     assert_eq!(bind_data.skeleton_name.unwrap(), "BoxWormRoot");
     assert_eq!(bind_data.joint_names, ["Root", "UpperArm", "LowerArm"]);
     assert_eq!(bind_data.vertex_weights.len(), 29);

--- a/src/document.rs
+++ b/src/document.rs
@@ -897,7 +897,7 @@ fn test_get_bind_data_set() {
 
     assert_eq!(bind_data.object_name, "BoxyWorm-mesh");
     assert!(bind_data.skeleton_name.is_some());
-    assert_eq!(bind_data.skeleton_name.unwrap().as_str(), "BoxWormRoot");
+    assert_eq!(bind_data.skeleton_name.as_ref().unwrap(), "BoxWormRoot");
     assert_eq!(bind_data.joint_names, ["Root", "UpperArm", "LowerArm"]);
     assert_eq!(bind_data.vertex_weights.len(), 29);
     assert_eq!(bind_data.weights.len(), 29);

--- a/src/document.rs
+++ b/src/document.rs
@@ -896,7 +896,8 @@ fn test_get_bind_data_set() {
     let bind_data = &bind_data_set.bind_data[0];
 
     assert_eq!(bind_data.object_name, "BoxyWorm-mesh");
-    assert_eq!(bind_data.skeleton_name, "BoxWormRoot");
+    assert_eq!(bind_data.skeleton_name.is_some());
+    assert_eq!(bind_data.skeleton_name.unwrap(), "BoxWormRoot");
     assert_eq!(bind_data.joint_names, ["Root", "UpperArm", "LowerArm"]);
     assert_eq!(bind_data.vertex_weights.len(), 29);
     assert_eq!(bind_data.weights.len(), 29);

--- a/src/document.rs
+++ b/src/document.rs
@@ -354,10 +354,9 @@ impl ColladaDocument {
     }
 
     fn get_bind_data(&self, controller_element: &xml::Element) -> Option<BindData> {
-
-        let skeleton_name = controller_element.get_attribute("name", None)?;
+        let skeleton_name = controller_element.get_attribute("name", None);
         let skin_element = controller_element.get_child("skin", self.get_ns())?;
-        let object_name = skin_element.get_attribute("source", None)?.trim_left_matches('#');
+        let object_name = skin_element.get_attribute("source", None)?.trim_start_matches('#');
 
         let vertex_weights_element = (skin_element.get_child("vertex_weights", self.get_ns()))?;
         let vertex_weights = (self.get_vertex_weights(vertex_weights_element))?;
@@ -378,7 +377,7 @@ impl ColladaDocument {
 
         Some(BindData{
             object_name: object_name.to_string(),
-            skeleton_name: skeleton_name.to_string(),
+            skeleton_name: skeleton_name.map(|s| s.to_string()),
             joint_names: joint_names,
             inverse_bind_poses: inverse_bind_poses,
             weights: weights,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub struct BindDataSet {
 #[derive(Debug)]
 pub struct BindData {
     pub object_name: String,
-    pub skeleton_name: String,
+    pub skeleton_name: Option<String>,
     pub joint_names: Vec<String>,
 
     /// Vertex weights, for vertex by index in mesh and joint by index in 'joint_names'


### PR DESCRIPTION
According to [the official COLLADA spec](https://www.khronos.org/files/collada_spec_1_4.pdf), the `name` property on a `controller` is optional.

The `get_bind_data` function currently returns `Option<None>` if it fails to read this property which causes it to ignore the rest of the data.

This PR fixes this issue and allows the parser to be used on DAE files exported from Maya 2019 (and most likely other ones).