### PR TITLE
Fix for blender 2.90.1 COLLADA exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "collada"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Steve Jahns <s.t.jahns@gmail.com>"]
 keywords = ["collada", "3d", "format", "piston"]
 description = "A library for parsing COLLADA documents for mesh, skeletal and animation data"


### PR DESCRIPTION
It seems the COLLADA exporter from the new version of blender (2.90.1) adds a wrapper node named ***animation*** between ***library_animations***  and the list of bone animations. I am writing a library on top of this very good parser and this fix allowed me to open collada files from blender 2.90.1.
It is still not possible to export multiple animations inside one DAE file but that is another problem coming from the blender collada exporter I think.
The library is https://github.com/bmatthieu3/rib if you want to check.

Maybe this fix break importations from the previous blender versions