### PR TITLE
Images & Lamberts

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -1,17 +1,20 @@
+use obj::*;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use std::str::FromStr;
-use std::collections::HashMap;
 use utils::*;
-use obj::*;
 use xml::Element;
 use xml::Xml::CharacterNode;
 
 use vecmath;
 use xml;
 
-use {Animation, BindDataSet, BindData, Skeleton, Joint, VertexWeight, JointIndex, ROOT_JOINT_PARENT_INDEX};
+use {
+    Animation, BindData, BindDataSet, Joint, JointIndex, Skeleton, VertexWeight,
+    ROOT_JOINT_PARENT_INDEX,
+};
 
 enum GeometryBindingType {
     Polylist,
@@ -40,12 +43,12 @@ impl GeometryBindingType {
 ///
 #[derive(Clone, Debug, PartialEq)]
 pub struct PhongEffect {
-  pub emission: [f32; 4],
-  pub ambient: [f32; 4],
-  pub diffuse: [f32; 4],
-  pub specular: [f32; 4],
-  pub shininess: f32,
-  pub index_of_refraction: f32
+    pub emission: [f32; 4],
+    pub ambient: [f32; 4],
+    pub diffuse: [f32; 4],
+    pub specular: [f32; 4],
+    pub shininess: f32,
+    pub index_of_refraction: f32,
 }
 
 // TODO: Add more effect types and then unify them under a technique enum.
@@ -54,15 +57,12 @@ pub struct PhongEffect {
 // Constant
 //
 
-
 pub struct ColladaDocument {
-    pub root_element: xml::Element
-    // TODO figure out how to cache skeletal and skinning data, as we need to
-    // access them multiple times
+    pub root_element: xml::Element, // TODO figure out how to cache skeletal and skinning data, as we need to
+                                    // access them multiple times
 }
 
 impl ColladaDocument {
-
     ///
     /// Construct a ColladaDocument for the XML document at the given path
     ///
@@ -71,13 +71,13 @@ impl ColladaDocument {
 
         let mut file = match file_result {
             Ok(file) => file,
-            Err(_) => return Err("Failed to open COLLADA file at path.")
+            Err(_) => return Err("Failed to open COLLADA file at path."),
         };
 
         let mut xml_string = String::new();
         match file.read_to_string(&mut xml_string) {
-            Ok(_) => {},
-            Err(_) => return Err("Failed to read COLLADA file.")
+            Ok(_) => {}
+            Err(_) => return Err("Failed to read COLLADA file."),
         };
 
         ColladaDocument::from_str(&xml_string)
@@ -88,138 +88,169 @@ impl ColladaDocument {
     ///
     pub fn from_str(xml_string: &str) -> Result<ColladaDocument, &'static str> {
         match xml_string.parse() {
-            Ok(root_element) => Ok(ColladaDocument{root_element: root_element}),
+            Ok(root_element) => Ok(ColladaDocument {
+                root_element: root_element,
+            }),
             Err(_) => Err("Error while parsing COLLADA document."),
         }
     }
 
     fn get_color(el: &Element) -> Option<[f32; 4]> {
-      let v:Vec<f32> = parse_string_to_vector(el.content_str().as_str());
-      if v.len() == 4 {
-        Some([v[0], v[1], v[2], v[3]])
-      } else {
-        None
-      }
+        let v: Vec<f32> = parse_string_to_vector(el.content_str().as_str());
+        if v.len() == 4 {
+            Some([v[0], v[1], v[2], v[3]])
+        } else {
+            None
+        }
     }
-
 
     ///
     /// Returns the library of effects.
     /// Current only supports Phong shading.
     ///
     pub fn get_effect_library(&self) -> HashMap<String, PhongEffect> {
-      let ns = self.get_ns();
-      let lib_effs = self.root_element.get_child("library_effects", ns)
-        .expect("Could not get library_effects from the document.");
-      lib_effs
-        .get_children("effect", ns)
-        .flat_map(|el:&Element| -> Option<(String, PhongEffect)> {
-          let id = el.get_attribute("id", None)
-            .expect(&format!("effect is missing its id. {:#?}", el));
-          let prof = el.get_child("profile_COMMON", ns)?;
-          let tech = prof.get_child("technique", ns)?;
-          let phong = tech.get_child("phong", ns)?;
-          let emission_color = phong
-            .get_child("emission", ns)
-            .expect("phong is missing emission")
-            .get_child("color", ns)
-            .expect("emission is missing color");
-          let emission = ColladaDocument::get_color(emission_color)
-            .expect("could not get emission color.");
-          let ambient_color = phong
-            .get_child("ambient", ns)
-            .expect("phong is missing ambient")
-            .get_child("color", ns)
-            .expect("ambient is missing color");
-          let ambient = ColladaDocument::get_color(ambient_color)
-            .expect("could not get ambient color.");
-          let diffuse_color = phong
-            .get_child("diffuse", ns)
-            .expect("phong is missing diffuse")
-            .get_child("color", ns)
-            .expect("diffuse is missing color");
-          let diffuse = ColladaDocument::get_color(diffuse_color)
-            .expect("could not get diffuse color.");
-          let specular_color = phong
-            .get_child("specular", ns)
-            .expect("phong is missing specular")
-            .get_child("color", ns)
-            .expect("specular is missing color");
-          let specular = ColladaDocument::get_color(specular_color)
-            .expect("could not get specular color.");
-          let shininess:f32 = phong
-            .get_child("shininess", ns)
-            .expect("phong is missing shininess")
-            .get_child("float", ns)
-            .expect("shininess is missing float")
-            .content_str().as_str()
-            .parse().ok().expect("could not parse shininess");
-          let index_of_refraction:f32 = phong
-            .get_child("index_of_refraction", ns)
-            .expect("phong is missing index_of_refraction")
-            .get_child("float", ns)
-            .expect("index_of_refraction is missing float")
-            .content_str().as_str()
-            .parse().ok().expect("could not parse index_of_refraction");
-          Some(
-            (id.to_string(), PhongEffect {
-              emission, ambient, diffuse, specular, shininess, index_of_refraction
+        let ns = self.get_ns();
+        let lib_effs = self
+            .root_element
+            .get_child("library_effects", ns)
+            .expect("Could not get library_effects from the document.");
+        lib_effs
+            .get_children("effect", ns)
+            .flat_map(|el: &Element| -> Option<(String, PhongEffect)> {
+                let id = el
+                    .get_attribute("id", None)
+                    .expect(&format!("effect is missing its id. {:#?}", el));
+                let prof = el.get_child("profile_COMMON", ns)?;
+                let tech = prof.get_child("technique", ns)?;
+                let phong = tech.get_child("phong", ns)?;
+                let emission_color = phong
+                    .get_child("emission", ns)
+                    .expect("phong is missing emission")
+                    .get_child("color", ns)
+                    .expect("emission is missing color");
+                let emission = ColladaDocument::get_color(emission_color)
+                    .expect("could not get emission color.");
+                let ambient_color = phong
+                    .get_child("ambient", ns)
+                    .expect("phong is missing ambient")
+                    .get_child("color", ns)
+                    .expect("ambient is missing color");
+                let ambient = ColladaDocument::get_color(ambient_color)
+                    .expect("could not get ambient color.");
+                let diffuse_color = phong
+                    .get_child("diffuse", ns)
+                    .expect("phong is missing diffuse")
+                    .get_child("color", ns)
+                    .expect("diffuse is missing color");
+                let diffuse = ColladaDocument::get_color(diffuse_color)
+                    .expect("could not get diffuse color.");
+                let specular_color = phong
+                    .get_child("specular", ns)
+                    .expect("phong is missing specular")
+                    .get_child("color", ns)
+                    .expect("specular is missing color");
+                let specular = ColladaDocument::get_color(specular_color)
+                    .expect("could not get specular color.");
+                let shininess: f32 = phong
+                    .get_child("shininess", ns)
+                    .expect("phong is missing shininess")
+                    .get_child("float", ns)
+                    .expect("shininess is missing float")
+                    .content_str()
+                    .as_str()
+                    .parse()
+                    .ok()
+                    .expect("could not parse shininess");
+                let index_of_refraction: f32 = phong
+                    .get_child("index_of_refraction", ns)
+                    .expect("phong is missing index_of_refraction")
+                    .get_child("float", ns)
+                    .expect("index_of_refraction is missing float")
+                    .content_str()
+                    .as_str()
+                    .parse()
+                    .ok()
+                    .expect("could not parse index_of_refraction");
+                Some((
+                    id.to_string(),
+                    PhongEffect {
+                        emission,
+                        ambient,
+                        diffuse,
+                        specular,
+                        shininess,
+                        index_of_refraction,
+                    },
+                ))
             })
-          )
-        })
-        .collect()
+            .collect()
     }
 
     pub fn get_material_to_effect(&self) -> HashMap<String, String> {
-      let ns = self.get_ns();
-      let lib_mats = self.root_element.get_child("library_materials", ns)
-        .expect("Could not get library_materials from the document");
-      lib_mats
-        .get_children("material", ns)
-        .flat_map(|el| {
-          let id = el.get_attribute("id", None)
-            .expect(&format!("material is missing its id. {:#?}", el));
-          let mut url:String = el
-            .get_child("instance_effect", ns).expect("could not get material instance_effect")
-            .get_attribute("url", None).expect("could not get material instance_effect url attribute")
-            .to_string();
-          if url.remove(0) == '#' {
-            Some((id.to_string(), url))
-          } else {
-            None
-          }
-        })
-        .collect()
+        let ns = self.get_ns();
+        let lib_mats = self
+            .root_element
+            .get_child("library_materials", ns)
+            .expect("Could not get library_materials from the document");
+        lib_mats
+            .get_children("material", ns)
+            .flat_map(|el| {
+                let id = el
+                    .get_attribute("id", None)
+                    .expect(&format!("material is missing its id. {:#?}", el));
+                let mut url: String = el
+                    .get_child("instance_effect", ns)
+                    .expect("could not get material instance_effect")
+                    .get_attribute("url", None)
+                    .expect("could not get material instance_effect url attribute")
+                    .to_string();
+                if url.remove(0) == '#' {
+                    Some((id.to_string(), url))
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
+    /// 
+    /// Returns a hashmap of <imageid, filename>
+    ///
     pub fn get_images(&self) -> HashMap<String, String> {
         let ns = self.get_ns();
-        let lib_images = self.root_element.get_child("library_images", ns).expect("Could not get library_images from the document");
-        lib_images.get_children("image", ns)
-        .flat_map(|el|| {
-            let id = el.get_attribute("id", ns)
-                .expect(&format!("image is missing its id. {:#?}", el)).to_string();
-            let file_name = el
-            .get_child("init_from", ns)
-            .expect(format!("Could not get image from the element {:?}", el))
-            .content_str();
-            Some((id, file_name))
-    }).collect()
-}
-
+        let lib_images = self
+            .root_element
+            .get_child("library_images", ns)
+            .expect("Could not get library_images from the document");
+        lib_images
+            .get_children("image", ns)
+            .flat_map(|el| {
+                let id = el
+                    .get_attribute("id", ns)
+                    .expect(&format!("image is missing its id. {:#?}", el))
+                    .to_string();
+                let file_name = el
+                    .get_child("init_from", ns)
+                    .expect("Could not get image from the element")
+                    .content_str();
+                Some((id, file_name))
+            })
+            .collect()
+    }
 
     ///
     /// Return a vector of all Animations in the Collada document
     ///
     pub fn get_animations(&self) -> Option<Vec<Animation>> {
-        match self.root_element.get_child("library_animations", self.get_ns()) {
+        match self
+            .root_element
+            .get_child("library_animations", self.get_ns())
+        {
             Some(library_animations) => {
                 let animations = library_animations.get_children("animation", self.get_ns());
                 Some(animations.filter_map(|a| self.get_animation(a)).collect())
             }
-            None => {
-                None
-            }
+            None => None,
         }
     }
 
@@ -227,56 +258,57 @@ impl ColladaDocument {
     /// Construct an Animation struct for the given <animation> element if possible
     ///
     fn get_animation(&self, animation_element: &Element) -> Option<Animation> {
+        let channel_element = animation_element
+            .get_child("channel", self.get_ns())
+            .expect("Missing channel element in animation element");
 
-      let channel_element = animation_element
-        .get_child("channel", self.get_ns())
-        .expect("Missing channel element in animation element");
+        let target = channel_element
+            .get_attribute("target", None)
+            .expect("Missing target attribute in animation channel element");
 
-      let target = channel_element
-        .get_attribute("target", None)
-        .expect("Missing target attribute in animation channel element");
+        let sampler_element = animation_element
+            .get_child("sampler", self.get_ns())
+            .expect("Missing sampler element in animation element");
 
-      let sampler_element = animation_element
-        .get_child("sampler", self.get_ns())
-        .expect("Missing sampler element in animation element");
+        // Note: Assuming INPUT for animation is 'time'
+        let time_input = self
+            .get_input(sampler_element, "INPUT")
+            .expect("Missing input element for animation INPUT (sample time)");
 
-      // Note: Assuming INPUT for animation is 'time'
-      let time_input = self
-        .get_input(sampler_element, "INPUT")
-        .expect("Missing input element for animation INPUT (sample time)");
+        let sample_times = self
+            .get_array_for_input(animation_element, time_input)
+            .expect("Missing / invalid source for animation INPUT");
 
-      let sample_times = self
-        .get_array_for_input(animation_element, time_input)
-        .expect("Missing / invalid source for animation INPUT");
+        // Note: Assuming OUTPUT for animation is a pose matrix
+        let pose_input = self
+            .get_input(sampler_element, "OUTPUT")
+            .expect("Missing input element for animation OUTPUT (pose transform)");
 
-      // Note: Assuming OUTPUT for animation is a pose matrix
-      let pose_input = self
-        .get_input(sampler_element, "OUTPUT")
-        .expect("Missing input element for animation OUTPUT (pose transform)");
+        let sample_poses_flat = self
+            .get_array_for_input(animation_element, pose_input)
+            .expect("Missing / invalid source for animation OUTPUT");
 
-      let sample_poses_flat = self
-        .get_array_for_input(animation_element, pose_input)
-        .expect("Missing / invalid source for animation OUTPUT");
+        // Convert flat array of floats into array of matrices
+        let sample_poses = to_matrix_array(sample_poses_flat);
 
-      // Convert flat array of floats into array of matrices
-      let sample_poses = to_matrix_array(sample_poses_flat);
-
-      Some(Animation {
-        target: target.to_string(),
-        sample_times: sample_times,
-        sample_poses: sample_poses
-      })
+        Some(Animation {
+            target: target.to_string(),
+            sample_times: sample_times,
+            sample_poses: sample_poses,
+        })
     }
 
     ///
     /// Populate and return an ObjSet for the meshes in the Collada document
     ///
     pub fn get_obj_set(&self) -> Option<ObjSet> {
-        let library_geometries = (self.root_element.get_child("library_geometries", self.get_ns()))?;
+        let library_geometries = (self
+            .root_element
+            .get_child("library_geometries", self.get_ns()))?;
         let geometries = library_geometries.get_children("geometry", self.get_ns());
-        let objects = geometries.filter_map( |g| { self.get_object(g) }).collect();
+        let objects = geometries.filter_map(|g| self.get_object(g)).collect();
 
-        Some(ObjSet{
+        Some(ObjSet {
             material_library: None,
             objects: objects,
         })
@@ -286,24 +318,36 @@ impl ColladaDocument {
     /// Populate and return a BindDataSet from the Collada document
     ///
     pub fn get_bind_data_set(&self) -> Option<BindDataSet> {
-        let library_controllers = (self.root_element.get_child("library_controllers", self.get_ns()))?;
+        let library_controllers = (self
+            .root_element
+            .get_child("library_controllers", self.get_ns()))?;
         let controllers = library_controllers.get_children("controller", self.get_ns());
-        let bind_data = controllers.filter_map( |c| { self.get_bind_data(c) }).collect();
-        Some(BindDataSet{ bind_data: bind_data })
+        let bind_data = controllers.filter_map(|c| self.get_bind_data(c)).collect();
+        Some(BindDataSet {
+            bind_data: bind_data,
+        })
     }
 
     ///
     ///
     ///
     pub fn get_skeletons(&self) -> Option<Vec<Skeleton>> {
-        let library_visual_scenes = (self.root_element.get_child("library_visual_scenes", self.get_ns()))?;
+        let library_visual_scenes = (self
+            .root_element
+            .get_child("library_visual_scenes", self.get_ns()))?;
         let visual_scene = (library_visual_scenes.get_child("visual_scene", self.get_ns()))?;
 
         let bind_data_set = (self.get_bind_data_set())?;
 
         let skeleton_ids: Vec<&str> = pre_order_iter(visual_scene)
             .filter(|e| e.name == "skeleton")
-            .filter_map(|s| if let CharacterNode(ref id) = s.children[0] { Some(&id[..]) } else { None })
+            .filter_map(|s| {
+                if let CharacterNode(ref id) = s.children[0] {
+                    Some(&id[..])
+                } else {
+                    None
+                }
+            })
             .map(|id| id.trim_left_matches('#'))
             .collect();
 
@@ -321,7 +365,6 @@ impl ColladaDocument {
     }
 
     fn get_skeleton(&self, root_element: &Element, bind_data: &BindData) -> Option<Skeleton> {
-
         let mut parent_index_stack: Vec<JointIndex> = vec![ROOT_JOINT_PARENT_INDEX];
         let mut joints = Vec::new();
         let mut bind_poses = Vec::new();
@@ -338,11 +381,15 @@ impl ColladaDocument {
 
             let joint_name = joint_element.get_attribute("id", None).unwrap().to_string();
 
-            let mut joint_names_with_bind_pose = bind_data.joint_names.iter().zip(bind_data.inverse_bind_poses.iter());
-            let inverse_bind_pose = match joint_names_with_bind_pose.find(|&(name, _)| *name == joint_name) {
-                Some((_, pose))  => *pose,
-                _                => vecmath::mat4_id(),
-            };
+            let mut joint_names_with_bind_pose = bind_data
+                .joint_names
+                .iter()
+                .zip(bind_data.inverse_bind_poses.iter());
+            let inverse_bind_pose =
+                match joint_names_with_bind_pose.find(|&(name, _)| *name == joint_name) {
+                    Some((_, pose)) => *pose,
+                    _ => vecmath::mat4_id(),
+                };
 
             joints.push(Joint {
                 inverse_bind_pose: inverse_bind_pose,
@@ -353,7 +400,10 @@ impl ColladaDocument {
             let pose_matrix_element = (joint_element.get_child("matrix", self.get_ns()))?;
             let pose_matrix_array = (get_array_content(pose_matrix_element))?;
             let mut pose_matrix = vecmath::mat4_id();
-            for (&array_value, matrix_value) in pose_matrix_array.iter().zip(pose_matrix.iter_mut().flat_map(|n| n.iter_mut())) {
+            for (&array_value, matrix_value) in pose_matrix_array
+                .iter()
+                .zip(pose_matrix.iter_mut().flat_map(|n| n.iter_mut()))
+            {
                 *matrix_value = array_value;
             }
 
@@ -371,7 +421,9 @@ impl ColladaDocument {
     fn get_bind_data(&self, controller_element: &xml::Element) -> Option<BindData> {
         let skeleton_name = controller_element.get_attribute("name", None);
         let skin_element = controller_element.get_child("skin", self.get_ns())?;
-        let object_name = skin_element.get_attribute("source", None)?.trim_start_matches('#');
+        let object_name = skin_element
+            .get_attribute("source", None)?
+            .trim_start_matches('#');
 
         let vertex_weights_element = (skin_element.get_child("vertex_weights", self.get_ns()))?;
         let vertex_weights = (self.get_vertex_weights(vertex_weights_element))?;
@@ -386,28 +438,31 @@ impl ColladaDocument {
 
         let inv_bind_matrix_input = (self.get_input(joints_element, "INV_BIND_MATRIX"))?;
 
-        let inverse_bind_poses = to_matrix_array(
-            (self.get_array_for_input(skin_element, inv_bind_matrix_input))?
-        );
+        let inverse_bind_poses =
+            to_matrix_array((self.get_array_for_input(skin_element, inv_bind_matrix_input))?);
 
-        Some(BindData{
+        Some(BindData {
             object_name: object_name.to_string(),
             skeleton_name: skeleton_name.map(|s| s.to_string()),
             joint_names: joint_names,
             inverse_bind_poses: inverse_bind_poses,
             weights: weights,
-            vertex_weights: vertex_weights
+            vertex_weights: vertex_weights,
         })
     }
 
-    fn get_vertex_weights(&self, vertex_weights_element: &xml::Element) -> Option<Vec<VertexWeight>> {
-
+    fn get_vertex_weights(
+        &self,
+        vertex_weights_element: &xml::Element,
+    ) -> Option<Vec<VertexWeight>> {
         let joint_index_offset = (self.get_input_offset(vertex_weights_element, "JOINT"))?;
         let weight_index_offset = (self.get_input_offset(vertex_weights_element, "WEIGHT"))?;
 
         let vcount_element = (vertex_weights_element.get_child("vcount", self.get_ns()))?;
         let weights_per_vertex: Vec<usize> = (get_array_content(vcount_element))?;
-        let input_count = vertex_weights_element.get_children("input", self.get_ns()).count();
+        let input_count = vertex_weights_element
+            .get_children("input", self.get_ns())
+            .count();
 
         let v_element = (vertex_weights_element.get_child("v", self.get_ns()))?;
         let joint_weight_indices: Vec<usize> = (get_array_content(v_element))?;
@@ -415,24 +470,22 @@ impl ColladaDocument {
 
         let mut vertex_indices: Vec<usize> = Vec::new();
         for (index, n) in weights_per_vertex.iter().enumerate() {
-            for _ in 0 .. *n {
+            for _ in 0..*n {
                 vertex_indices.push(index);
             }
-
         }
 
-        let vertex_weights = vertex_indices.iter().filter_map( |vertex_index| {
-            match joint_weight_iter.next() {
-                Some(joint_weight) => {
-                    Some(VertexWeight {
-                        vertex: *vertex_index,
-                        joint: joint_weight[joint_index_offset] as JointIndex,
-                        weight: joint_weight[weight_index_offset],
-                    })
-                }
-                None => None
-            }
-        }).collect();
+        let vertex_weights = vertex_indices
+            .iter()
+            .filter_map(|vertex_index| match joint_weight_iter.next() {
+                Some(joint_weight) => Some(VertexWeight {
+                    vertex: *vertex_index,
+                    joint: joint_weight[joint_index_offset] as JointIndex,
+                    weight: joint_weight[weight_index_offset],
+                }),
+                None => None,
+            })
+            .collect();
 
         Some(vertex_weights)
     }
@@ -445,52 +498,61 @@ impl ColladaDocument {
         //let binding_type = (self.get_geometry_binding_type(mesh_element))?;
 
         let mut first_primitive_element = None;
-        'find_primitive: for t in [GeometryBindingType::Polylist, GeometryBindingType::Triangles].iter() {
-          first_primitive_element = mesh_element.get_child(t.name(), self.get_ns());
-          if first_primitive_element.is_some() {
-            break 'find_primitive;
-          }
+        'find_primitive: for t in [
+            GeometryBindingType::Polylist,
+            GeometryBindingType::Triangles,
+        ]
+        .iter()
+        {
+            first_primitive_element = mesh_element.get_child(t.name(), self.get_ns());
+            if first_primitive_element.is_some() {
+                break 'find_primitive;
+            }
         }
         let first_primitive_element = first_primitive_element?;
 
         let positions_input = (self.get_input(first_primitive_element, "VERTEX"))?;
         let positions_array = (self.get_array_for_input(mesh_element, positions_input))?;
-        let positions: Vec<_> = positions_array.chunks(3).map(|coords| {
-            Vertex {
+        let positions: Vec<_> = positions_array
+            .chunks(3)
+            .map(|coords| Vertex {
                 x: coords[0],
                 y: coords[1],
                 z: coords[2],
-            }
-        }).collect();
+            })
+            .collect();
 
         let normals = {
             match self.get_input(first_primitive_element, "NORMAL") {
                 Some(normals_input) => {
                     let normals_array = (self.get_array_for_input(mesh_element, normals_input))?;
-                    normals_array.chunks(3).map(|coords| {
-                        Normal {
+                    normals_array
+                        .chunks(3)
+                        .map(|coords| Normal {
                             x: coords[0],
                             y: coords[1],
                             z: coords[2],
-                        }
-                    }).collect()
+                        })
+                        .collect()
                 }
-                None => Vec::new()
+                None => Vec::new(),
             }
         };
 
         let texcoords = {
             match self.get_input(first_primitive_element, "TEXCOORD") {
                 Some(texcoords_input) => {
-                    let texcoords_array = (self.get_array_for_input(mesh_element, texcoords_input))?;
-                    texcoords_array.chunks(2).map(|coords| {
-                        TVertex {
+                    let texcoords_array =
+                        (self.get_array_for_input(mesh_element, texcoords_input))?;
+                    texcoords_array
+                        .chunks(2)
+                        .map(|coords| TVertex {
                             x: coords[0],
                             y: coords[1],
-                        }
-                    }).collect()
+                        })
+                        .collect()
                 }
-                None => Vec::new()
+                None => Vec::new(),
             }
         };
 
@@ -501,26 +563,45 @@ impl ColladaDocument {
                 let skeleton = &skeletons[0];
                 // TODO cache bind_data_set
                 let bind_data_set = (self.get_bind_data_set())?;
-                let bind_data_opt = bind_data_set.bind_data.iter().find(|bind_data| bind_data.object_name == id);
+                let bind_data_opt = bind_data_set
+                    .bind_data
+                    .iter()
+                    .find(|bind_data| bind_data.object_name == id);
 
                 if let Some(bind_data) = bind_data_opt {
                     // Build an array of joint weights for each vertex
                     // Initialize joint weights array with no weights for any vertex
-                    let mut joint_weights = vec![JointWeights { joints: [0; 4], weights: [0.0; 4] }; positions.len()];
+                    let mut joint_weights = vec![
+                        JointWeights {
+                            joints: [0; 4],
+                            weights: [0.0; 4]
+                        };
+                        positions.len()
+                    ];
 
                     for vertex_weight in bind_data.vertex_weights.iter() {
                         let joint_name = &bind_data.joint_names[vertex_weight.joint as usize];
-                        let vertex_joint_weights: &mut JointWeights = &mut joint_weights[vertex_weight.vertex];
+                        let vertex_joint_weights: &mut JointWeights =
+                            &mut joint_weights[vertex_weight.vertex];
 
-                        if let Some((next_index, _)) = vertex_joint_weights.weights.iter().enumerate().find(|&(_, weight)| *weight == 0.0) {
-                            if let Some((joint_index, _)) = skeleton.joints.iter().enumerate()
-                                .find(|&(_, j)| &j.name == joint_name) {
+                        if let Some((next_index, _)) = vertex_joint_weights
+                            .weights
+                            .iter()
+                            .enumerate()
+                            .find(|&(_, weight)| *weight == 0.0)
+                        {
+                            if let Some((joint_index, _)) = skeleton
+                                .joints
+                                .iter()
+                                .enumerate()
+                                .find(|&(_, j)| &j.name == joint_name)
+                            {
                                 vertex_joint_weights.joints[next_index] = joint_index;
-                                vertex_joint_weights.weights[next_index] = bind_data.weights[vertex_weight.weight];
+                                vertex_joint_weights.weights[next_index] =
+                                    bind_data.weights[vertex_weight.weight];
                             } else {
                                 error!("Couldn't find joint: {}", joint_name);
                             }
-
                         } else {
                             error!("Too many joint influences for vertex");
                         }
@@ -529,8 +610,8 @@ impl ColladaDocument {
                 } else {
                     Vec::new()
                 }
-            },
-            None => Vec::new()
+            }
+            None => Vec::new(),
         };
 
         Some(Object {
@@ -554,39 +635,54 @@ impl ColladaDocument {
         }
     }
 
-    fn get_input_offset(&self, parent_element: &xml::Element, semantic : &str) -> Option<usize> {
+    fn get_input_offset(&self, parent_element: &xml::Element, semantic: &str) -> Option<usize> {
         let mut inputs = parent_element.get_children("input", self.get_ns());
-        let input:&Element = inputs.find( |i| {
+        let input: &Element = inputs.find(|i| {
             if let Some(s) = i.get_attribute("semantic", None) {
                 s == semantic
             } else {
                 false
             }
         })?;
-      input
-        .get_attribute("offset", None)
-        .expect("input is missing offest")
-        .parse::<usize>()
-        .ok()
+        input
+            .get_attribute("offset", None)
+            .expect("input is missing offest")
+            .parse::<usize>()
+            .ok()
     }
 
-  ///
-    fn get_input<'a>(&'a self, parent: &'a Element, semantic : &str) -> Option<&'a Element> {
+    ///
+    fn get_input<'a>(&'a self, parent: &'a Element, semantic: &str) -> Option<&'a Element> {
         let mut inputs = parent.get_children("input", self.get_ns());
-        match inputs.find( |i| {
-            if let Some(s) = i.get_attribute("semantic", None) { s == semantic } else { false }
-        })
-        {
+        match inputs.find(|i| {
+            if let Some(s) = i.get_attribute("semantic", None) {
+                s == semantic
+            } else {
+                false
+            }
+        }) {
             Some(e) => Some(e),
             None => None,
         }
     }
 
-    fn get_input_source<'a>(&'a self, parent_element: &'a xml::Element, input_element: &'a xml::Element) -> Option<&'a xml::Element> {
+    fn get_input_source<'a>(
+        &'a self,
+        parent_element: &'a xml::Element,
+        input_element: &'a xml::Element,
+    ) -> Option<&'a xml::Element> {
         let source_id = (input_element.get_attribute("source", None))?;
 
-        if let Some(element) = parent_element.children.iter()
-            .filter_map(|node| { if let &xml::Xml::ElementNode(ref e) = node { Some(e) } else { None } })
+        if let Some(element) = parent_element
+            .children
+            .iter()
+            .filter_map(|node| {
+                if let &xml::Xml::ElementNode(ref e) = node {
+                    Some(e)
+                } else {
+                    None
+                }
+            })
             .find(|e| {
                 if let Some(id) = e.get_attribute("id", None) {
                     let id = "#".to_string() + id;
@@ -608,15 +704,14 @@ impl ColladaDocument {
 
     fn get_array_for_input<T: FromStr>(&self, parent: &Element, input: &Element) -> Option<Vec<T>> {
         let source = (self.get_input_source(parent, input))?;
-        let array_element = (
-            if let Some(float_array) = source.get_child("float_array", self.get_ns()) {
+        let array_element =
+            (if let Some(float_array) = source.get_child("float_array", self.get_ns()) {
                 Some(float_array)
             } else if let Some(name_array) = source.get_child("Name_array", self.get_ns()) {
                 Some(name_array)
             } else {
                 None
-            }
-        )?;
+            })?;
         get_array_content(array_element)
     }
 
@@ -696,43 +791,49 @@ impl ColladaDocument {
         let p_element = (prim_element.get_child("p", self.get_ns()))?;
         let indices: Vec<usize> = (get_array_content(p_element))?;
 
-        let input_count = prim_element.get_children("input", self.get_ns())
-          .filter(|c| if let Some(set) = c.get_attribute("set", None) {
-            return set == "0"
-          } else {
-            true
-          })
-          .count();
+        let input_count = prim_element
+            .get_children("input", self.get_ns())
+            .filter(|c| {
+                if let Some(set) = c.get_attribute("set", None) {
+                    return set == "0";
+                } else {
+                    true
+                }
+            })
+            .count();
 
         let position_offset = (self.get_input_offset(prim_element, "VERTEX"))?;
 
         let normal_offset_opt = self.get_input_offset(prim_element, "NORMAL");
         let texcoord_offset_opt = self.get_input_offset(prim_element, "TEXCOORD");
 
-        let vtn_indices: Vec<VTNIndex> = indices.chunks(input_count).map( |indices| {
-            let position_index = indices[position_offset];
+        let vtn_indices: Vec<VTNIndex> = indices
+            .chunks(input_count)
+            .map(|indices| {
+                let position_index = indices[position_offset];
 
-            let normal_index_opt = match normal_offset_opt {
-                Some(normal_offset) => Some(indices[normal_offset]),
-                None => None
-            };
+                let normal_index_opt = match normal_offset_opt {
+                    Some(normal_offset) => Some(indices[normal_offset]),
+                    None => None,
+                };
 
-            let texcoord_index_opt = match texcoord_offset_opt {
-                Some(texcoord_offset) => Some(indices[texcoord_offset]),
-                None => None
-            };
+                let texcoord_index_opt = match texcoord_offset_opt {
+                    Some(texcoord_offset) => Some(indices[texcoord_offset]),
+                    None => None,
+                };
 
-            (position_index, texcoord_index_opt, normal_index_opt)
-        }).collect();
+                (position_index, texcoord_index_opt, normal_index_opt)
+            })
+            .collect();
 
         Some(vtn_indices)
     }
 
-  fn get_material(&self, primitive_el: &xml::Element) -> Option<String> {
-    primitive_el
-      .get_attribute("material", None)
-      .map(|s| s.to_string())
-  }
+    fn get_material(&self, primitive_el: &xml::Element) -> Option<String> {
+        primitive_el
+            .get_attribute("material", None)
+            .map(|s| s.to_string())
+    }
 
     //fn get_geometry_binding_type(&self, mesh_element: &xml::Element) -> Option<GeometryBindingType> {
     //    if mesh_element.get_child(GeometryBindingType::Polylist.name(), self.get_ns()).is_some() {
@@ -745,68 +846,90 @@ impl ColladaDocument {
     //}
 
     fn get_mesh_elements(&self, mesh_element: &xml::Element) -> Option<Vec<PrimitiveElement>> {
-      let mut prims = vec![];
-      for child in &mesh_element.children {
-        match child {
-          xml::Xml::ElementNode(el) => {
-            if el.name == GeometryBindingType::Polylist.name() {
-              let shapes = self
-                .get_polylist_shape(&el)
-                .expect("Polylist had no shapes.");
-              let material = self.get_material(&el);
-              let polylist = Polylist {
-                shapes, material
-              };
-              prims.push(PrimitiveElement::Polylist(polylist))
-            } else if el.name == GeometryBindingType::Triangles.name() {
-              let material = self.get_material(&el);
-              let triangles = self
-                .get_triangles(&el, material)
-                .expect("Triangles had no indices.");
-              prims.push(PrimitiveElement::Triangles(triangles))
+        let mut prims = vec![];
+        for child in &mesh_element.children {
+            match child {
+                xml::Xml::ElementNode(el) => {
+                    if el.name == GeometryBindingType::Polylist.name() {
+                        let shapes = self
+                            .get_polylist_shape(&el)
+                            .expect("Polylist had no shapes.");
+                        let material = self.get_material(&el);
+                        let polylist = Polylist { shapes, material };
+                        prims.push(PrimitiveElement::Polylist(polylist))
+                    } else if el.name == GeometryBindingType::Triangles.name() {
+                        let material = self.get_material(&el);
+                        let triangles = self
+                            .get_triangles(&el, material)
+                            .expect("Triangles had no indices.");
+                        prims.push(PrimitiveElement::Triangles(triangles))
+                    }
+                }
+                _ => {}
             }
-          }
-          _ => {}
         }
-      }
 
-      if prims.is_empty() {
-        None
-      } else {
-        Some(prims)
-      }
+        if prims.is_empty() {
+            None
+        } else {
+            Some(prims)
+        }
     }
 
-    fn get_triangles(&self, triangles: &xml::Element, material: Option<String>) -> Option<Triangles> {
-        let count_str:&str = triangles.get_attribute("count", None)?;
+    fn get_triangles(
+        &self,
+        triangles: &xml::Element,
+        material: Option<String>,
+    ) -> Option<Triangles> {
+        let count_str: &str = triangles.get_attribute("count", None)?;
         let count = count_str.parse::<usize>().ok().unwrap();
-        
+
         let vertices = self.get_vertex_indices(triangles).map(|vertex_indices| {
             let mut vertex_iter = vertex_indices.iter();
-            (0..count).map(|_| {
-                (*vertex_iter.next().unwrap(), *vertex_iter.next().unwrap(), *vertex_iter.next().unwrap())
-            }).collect()
+            (0..count)
+                .map(|_| {
+                    (
+                        *vertex_iter.next().unwrap(),
+                        *vertex_iter.next().unwrap(),
+                        *vertex_iter.next().unwrap(),
+                    )
+                })
+                .collect()
         })?;
 
-        let tex_vertices = self.get_texcoord_indices(triangles).map(|texcoord_indices| {
-            let mut texcoord_iter = texcoord_indices.iter();
-            (0..count).map(|_| {
-                (*texcoord_iter.next().unwrap(), *texcoord_iter.next().unwrap(), *texcoord_iter.next().unwrap())
-            }).collect()
-        });
+        let tex_vertices = self
+            .get_texcoord_indices(triangles)
+            .map(|texcoord_indices| {
+                let mut texcoord_iter = texcoord_indices.iter();
+                (0..count)
+                    .map(|_| {
+                        (
+                            *texcoord_iter.next().unwrap(),
+                            *texcoord_iter.next().unwrap(),
+                            *texcoord_iter.next().unwrap(),
+                        )
+                    })
+                    .collect()
+            });
 
         let normals = self.get_normal_indices(triangles).map(|normal_indices| {
             let mut normal_iter = normal_indices.iter();
-            (0..count).map(|_| {
-                (*normal_iter.next().unwrap(), *normal_iter.next().unwrap(), *normal_iter.next().unwrap())
-            }).collect()
+            (0..count)
+                .map(|_| {
+                    (
+                        *normal_iter.next().unwrap(),
+                        *normal_iter.next().unwrap(),
+                        *normal_iter.next().unwrap(),
+                    )
+                })
+                .collect()
         });
-        
+
         Some(Triangles {
             vertices,
             tex_vertices,
             normals,
-            material
+            material,
         })
     }
 
@@ -817,20 +940,28 @@ impl ColladaDocument {
         let vertex_counts: Vec<usize> = (get_array_content(vcount_element))?;
 
         let mut vtn_iter = vtn_indices.iter();
-        let shapes = vertex_counts.iter().map(|vertex_count| {
-            match *vertex_count {
-                1 => Shape::Point(*vtn_iter.next().unwrap()),
-                2 => Shape::Line(*vtn_iter.next().unwrap(), *vtn_iter.next().unwrap()),
-                3 => Shape::Triangle(*vtn_iter.next().unwrap(), *vtn_iter.next().unwrap(), *vtn_iter.next().unwrap()),
-                n => {
-                    // Polys with more than 3 vertices not supported - try to advance and continue
-                    // TODO attempt to triangle-fy? (take a look at wavefront_obj)
-                    for _ in 0 .. n { vtn_iter.next(); };
-                    Shape::Point((0, None, None))
+        let shapes = vertex_counts
+            .iter()
+            .map(|vertex_count| {
+                match *vertex_count {
+                    1 => Shape::Point(*vtn_iter.next().unwrap()),
+                    2 => Shape::Line(*vtn_iter.next().unwrap(), *vtn_iter.next().unwrap()),
+                    3 => Shape::Triangle(
+                        *vtn_iter.next().unwrap(),
+                        *vtn_iter.next().unwrap(),
+                        *vtn_iter.next().unwrap(),
+                    ),
+                    n => {
+                        // Polys with more than 3 vertices not supported - try to advance and continue
+                        // TODO attempt to triangle-fy? (take a look at wavefront_obj)
+                        for _ in 0..n {
+                            vtn_iter.next();
+                        }
+                        Shape::Point((0, None, None))
+                    }
                 }
-            }
-        }).collect();
-
+            })
+            .collect();
 
         Some(shapes)
     }
@@ -854,21 +985,25 @@ fn test_get_obj_set() {
 
     let ref prim = geometry.mesh[0];
     if let PrimitiveElement::Polylist(polylist) = prim {
-      assert_eq!(polylist.shapes.len(), 28);
-      let ref shape = polylist.shapes[1];
-      if let &Shape::Triangle((position_index, Some(texture_index), Some(normal_index)), _, _) = shape {
-          assert_eq!(position_index, 7);
-          assert_eq!(texture_index, 3);
-          assert_eq!(normal_index, 1);
-      } else {
-          assert!(false);
-      }
+        assert_eq!(polylist.shapes.len(), 28);
+        let ref shape = polylist.shapes[1];
+        if let &Shape::Triangle((position_index, Some(texture_index), Some(normal_index)), _, _) =
+            shape
+        {
+            assert_eq!(position_index, 7);
+            assert_eq!(texture_index, 3);
+            assert_eq!(normal_index, 1);
+        } else {
+            assert!(false);
+        }
     }
 }
 
 #[test]
 fn test_get_obj_set_triangles_geometry() {
-    let collada_document = ColladaDocument::from_path(&Path::new("test_assets/test_cube_triangles_geometry.dae")).unwrap();
+    let collada_document =
+        ColladaDocument::from_path(&Path::new("test_assets/test_cube_triangles_geometry.dae"))
+            .unwrap();
     let obj_set = collada_document.get_obj_set().unwrap();
     assert_eq!(obj_set.objects.len(), 1);
 
@@ -882,25 +1017,25 @@ fn test_get_obj_set_triangles_geometry() {
     let ref geometry = object.geometry[0];
 
     let ref prim = geometry.mesh[0];
-    match prim  {
-      PrimitiveElement::Triangles(triangles) => {
-        assert_eq!(triangles.vertices.len(), 12);
+    match prim {
+        PrimitiveElement::Triangles(triangles) => {
+            assert_eq!(triangles.vertices.len(), 12);
 
-        let position_index = triangles.vertices[1].0;
-        assert_eq!(position_index, 7);
+            let position_index = triangles.vertices[1].0;
+            assert_eq!(position_index, 7);
 
-        if let Some(ref normals) = triangles.normals {
-          assert_eq!(normals.len(), 12);
-          
-          let normal_index = normals[1].0;
-          assert_eq!(normal_index, 1);
-        } else {
-          assert!(false, "Triangle is missing a normal.");
+            if let Some(ref normals) = triangles.normals {
+                assert_eq!(normals.len(), 12);
+
+                let normal_index = normals[1].0;
+                assert_eq!(normal_index, 1);
+            } else {
+                assert!(false, "Triangle is missing a normal.");
+            }
         }
-      }
-      x => {
-        assert!(false, "Not a polylist: {:#?}", x);
-      }
+        x => {
+            assert!(false, "Not a polylist: {:#?}", x);
+        }
     }
 }
 
@@ -965,6 +1100,7 @@ fn test_get_animations() {
 
 #[test]
 fn test_get_obj_set_noskeleton() {
-    let collada_document = ColladaDocument::from_path(&Path::new("test_assets/test_noskeleton.dae")).unwrap();
+    let collada_document =
+        ColladaDocument::from_path(&Path::new("test_assets/test_noskeleton.dae")).unwrap();
     collada_document.get_obj_set().unwrap();
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -247,7 +247,7 @@ impl ColladaDocument {
             .get_children("image", ns)
             .flat_map(|el| {
                 let id = el
-                    .get_attribute("id", ns)
+                    .get_attribute("id", None)
                     .expect(&format!("image is missing its id. {:#?}", el))
                     .to_string();
                 let file_name = el

--- a/src/document.rs
+++ b/src/document.rs
@@ -62,7 +62,6 @@ pub enum LambertDiffuse {
 pub struct LambertEffect {
     pub emission: [f32; 4],
     pub diffuse: LambertDiffuse,
-    pub specular: [f32; 4],
     pub index_of_refraction: f32,
 }
 
@@ -125,17 +124,17 @@ impl ColladaDocument {
         }
     }
 
-    fn get_lambert(&self, phong: &Element, ns: Option<&str>) -> LambertEffect {
-        let emission_color = phong
+    fn get_lambert(&self, lamb: &Element, ns: Option<&str>) -> LambertEffect {
+        let emission_color = lamb
             .get_child("emission", ns)
-            .expect("phong is missing emission")
+            .expect("lambert is missing emission")
             .get_child("color", ns)
             .expect("emission is missing color");
         let emission =
             ColladaDocument::get_color(emission_color).expect("could not get emission color.");
-        let diffuse_element = phong
+        let diffuse_element = lamb
             .get_child("diffuse", ns)
-            .expect("phong is missing diffuse");
+            .expect("lambert is missing diffuse");
 
         let diffuse_texture = diffuse_element.get_child("texture", ns);
 
@@ -156,16 +155,9 @@ impl ColladaDocument {
             diffuse = LambertDiffuse::Color(diffuse_color);
         }
 
-        let specular_color = phong
-            .get_child("specular", ns)
-            .expect("phong is missing specular")
-            .get_child("color", ns)
-            .expect("specular is missing color");
-        let specular =
-            ColladaDocument::get_color(specular_color).expect("could not get specular color.");
-        let index_of_refraction: f32 = phong
+        let index_of_refraction: f32 = lamb
             .get_child("index_of_refraction", ns)
-            .expect("phong is missing index_of_refraction")
+            .expect("lambert is missing index_of_refraction")
             .get_child("float", ns)
             .expect("index_of_refraction is missing float")
             .content_str()
@@ -178,7 +170,6 @@ impl ColladaDocument {
             diffuse,
             emission,
             index_of_refraction,
-            specular,
         }
     }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -45,19 +45,31 @@ impl GeometryBindingType {
 pub struct PhongEffect {
     pub emission: [f32; 4],
     pub ambient: [f32; 4],
-    pub diffuse: Diffuse,
+    pub diffuse: [f32; 4],
     pub specular: [f32; 4],
     pub shininess: f32,
     pub index_of_refraction: f32,
 }
-
 ///
 /// Can be a plain color or point to a texture in the images library
 ///
 #[derive(Clone, Debug, PartialEq)]
-pub enum Diffuse {
+pub enum LambertDiffuse {
     Color([f32; 4]),
     Texture(String),
+}
+#[derive(Clone, Debug, PartialEq)]
+pub struct LambertEffect {
+    pub emission: [f32; 4],
+    pub diffuse: LambertDiffuse,
+    pub specular: [f32; 4],
+    pub index_of_refraction: f32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum MaterialEffect {
+    Phong(PhongEffect),
+    Lambert(LambertEffect),
 }
 
 // TODO: Add more effect types and then unify them under a technique enum.
@@ -113,11 +125,129 @@ impl ColladaDocument {
         }
     }
 
+    fn get_lambert(&self, phong: &Element, ns: Option<&str>) -> LambertEffect {
+        let emission_color = phong
+            .get_child("emission", ns)
+            .expect("phong is missing emission")
+            .get_child("color", ns)
+            .expect("emission is missing color");
+        let emission =
+            ColladaDocument::get_color(emission_color).expect("could not get emission color.");
+        let diffuse_element = phong
+            .get_child("diffuse", ns)
+            .expect("phong is missing diffuse");
+
+        let diffuse_texture = diffuse_element.get_child("texture", ns);
+
+        let diffuse;
+        if let Some(texture) = diffuse_texture {
+            diffuse = LambertDiffuse::Texture(
+                texture
+                    .get_attribute("texture", None)
+                    .expect("No texture attribute on texture")
+                    .to_string(),
+            );
+        } else {
+            let diffuse_element_color = diffuse_element
+                .get_child("color", ns)
+                .expect("diffuse is missing color");
+            let diffuse_color = ColladaDocument::get_color(diffuse_element_color)
+                .expect("could not get diffuse color.");
+            diffuse = LambertDiffuse::Color(diffuse_color);
+        }
+
+        let specular_color = phong
+            .get_child("specular", ns)
+            .expect("phong is missing specular")
+            .get_child("color", ns)
+            .expect("specular is missing color");
+        let specular =
+            ColladaDocument::get_color(specular_color).expect("could not get specular color.");
+        let index_of_refraction: f32 = phong
+            .get_child("index_of_refraction", ns)
+            .expect("phong is missing index_of_refraction")
+            .get_child("float", ns)
+            .expect("index_of_refraction is missing float")
+            .content_str()
+            .as_str()
+            .parse()
+            .ok()
+            .expect("could not parse index_of_refraction");
+
+        LambertEffect {
+            diffuse,
+            emission,
+            index_of_refraction,
+            specular,
+        }
+    }
+
+    fn get_phong(&self, phong: &Element, ns: Option<&str>) -> PhongEffect {
+        let emission_color = phong
+            .get_child("emission", ns)
+            .expect("phong is missing emission")
+            .get_child("color", ns)
+            .expect("emission is missing color");
+        let emission =
+            ColladaDocument::get_color(emission_color).expect("could not get emission color.");
+        let ambient_color = phong
+            .get_child("ambient", ns)
+            .expect("phong is missing ambient")
+            .get_child("color", ns)
+            .expect("ambient is missing color");
+        let ambient =
+            ColladaDocument::get_color(ambient_color).expect("could not get ambient color.");
+        let diffuse = phong
+            .get_child("diffuse", ns)
+            .expect("phong is missing diffuse");
+        let diffuse_color = diffuse
+            .get_child("color", ns)
+            .expect("diffuse is missing color");
+        let diffuse =
+            ColladaDocument::get_color(diffuse_color).expect("could not get diffuse color.");
+        let specular_color = phong
+            .get_child("specular", ns)
+            .expect("phong is missing specular")
+            .get_child("color", ns)
+            .expect("specular is missing color");
+        let specular =
+            ColladaDocument::get_color(specular_color).expect("could not get specular color.");
+        let shininess: f32 = phong
+            .get_child("shininess", ns)
+            .expect("phong is missing shininess")
+            .get_child("float", ns)
+            .expect("shininess is missing float")
+            .content_str()
+            .as_str()
+            .parse()
+            .ok()
+            .expect("could not parse shininess");
+        let index_of_refraction: f32 = phong
+            .get_child("index_of_refraction", ns)
+            .expect("phong is missing index_of_refraction")
+            .get_child("float", ns)
+            .expect("index_of_refraction is missing float")
+            .content_str()
+            .as_str()
+            .parse()
+            .ok()
+            .expect("could not parse index_of_refraction");
+
+        PhongEffect {
+            ambient,
+            diffuse,
+            emission,
+            index_of_refraction,
+            shininess,
+            specular,
+        }
+    }
+
     ///
     /// Returns the library of effects.
     /// Current only supports Phong shading.
     ///
-    pub fn get_effect_library(&self) -> HashMap<String, PhongEffect> {
+    pub fn get_effect_library(&self) -> HashMap<String, MaterialEffect> {
         let ns = self.get_ns();
         let lib_effs = self
             .root_element
@@ -125,84 +255,24 @@ impl ColladaDocument {
             .expect("Could not get library_effects from the document.");
         lib_effs
             .get_children("effect", ns)
-            .flat_map(|el: &Element| -> Option<(String, PhongEffect)> {
+            .flat_map(|el: &Element| -> Option<(String, MaterialEffect)> {
                 let id = el
                     .get_attribute("id", None)
                     .expect(&format!("effect is missing its id. {:#?}", el));
                 let prof = el.get_child("profile_COMMON", ns)?;
                 let tech = prof.get_child("technique", ns)?;
-                let phong = tech.get_child("phong", ns)?;
-                let emission_color = phong
-                    .get_child("emission", ns)
-                    .expect("phong is missing emission")
-                    .get_child("color", ns)
-                    .expect("emission is missing color");
-                let emission = ColladaDocument::get_color(emission_color)
-                    .expect("could not get emission color.");
-                let ambient_color = phong
-                    .get_child("ambient", ns)
-                    .expect("phong is missing ambient")
-                    .get_child("color", ns)
-                    .expect("ambient is missing color");
-                let ambient = ColladaDocument::get_color(ambient_color)
-                    .expect("could not get ambient color.");
-                let diffuse = phong
-                    .get_child("diffuse", ns)
-                    .expect("phong is missing diffuse");
-                let diffuse_texture = diffuse.get_child("texture", ns);
-                let diffuse_color = diffuse.get_child("color", ns);
-                let diffuse = match diffuse_texture {
-                    Some(texture) => Diffuse::Texture(
-                        texture
-                            .get_attribute("texture", ns)
-                            .expect("texture had no texture")
-                            .to_string(),
-                    ),
-                    _ => Diffuse::Color(
-                        ColladaDocument::get_color(
-                            diffuse_color.expect("diffuse is missing color"),
-                        )
-                        .expect("could not get diffuse color."),
-                    ),
+                let phong = tech.get_child("phong", ns);
+                if let Some(p) = phong {
+                    let phong_effect = self.get_phong(p, ns);
+                    return Some((id.to_string(), MaterialEffect::Phong(phong_effect)));
                 };
-                let specular_color = phong
-                    .get_child("specular", ns)
-                    .expect("phong is missing specular")
-                    .get_child("color", ns)
-                    .expect("specular is missing color");
-                let specular = ColladaDocument::get_color(specular_color)
-                    .expect("could not get specular color.");
-                let shininess: f32 = phong
-                    .get_child("shininess", ns)
-                    .expect("phong is missing shininess")
-                    .get_child("float", ns)
-                    .expect("shininess is missing float")
-                    .content_str()
-                    .as_str()
-                    .parse()
-                    .ok()
-                    .expect("could not parse shininess");
-                let index_of_refraction: f32 = phong
-                    .get_child("index_of_refraction", ns)
-                    .expect("phong is missing index_of_refraction")
-                    .get_child("float", ns)
-                    .expect("index_of_refraction is missing float")
-                    .content_str()
-                    .as_str()
-                    .parse()
-                    .ok()
-                    .expect("could not parse index_of_refraction");
-                Some((
-                    id.to_string(),
-                    PhongEffect {
-                        emission,
-                        ambient,
-                        diffuse,
-                        specular,
-                        shininess,
-                        index_of_refraction,
-                    },
-                ))
+                let lambert = tech.get_child("lambert", ns);
+                if let Some(lam) = lambert {
+                    let lambert_effect = self.get_lambert(lam, ns);
+                    return Some((id.to_string(), MaterialEffect::Lambert(lambert_effect)));
+                };
+
+                None
             })
             .collect()
     }

--- a/src/document.rs
+++ b/src/document.rs
@@ -192,6 +192,21 @@ impl ColladaDocument {
         .collect()
     }
 
+    pub fn get_images(&self) -> HashMap<String, String> {
+        let ns = self.get_ns();
+        let lib_images = self.root_element.get_child("library_images", ns).expect("Could not get library_images from the document");
+        lib_images.get_children("image", ns)
+        .flat_map(|el|| {
+            let id = el.get_attribute("id", ns)
+                .expect(&format!("image is missing its id. {:#?}", el)).to_string();
+            let file_name = el
+            .get_child("init_from", ns)
+            .expect(format!("Could not get image from the element {:?}", el))
+            .content_str();
+            Some((id, file_name))
+    }).collect()
+}
+
 
     ///
     /// Return a vector of all Animations in the Collada document


### PR DESCRIPTION
Not sure if you want this. Will still need to do more with the mapping of materials to images, but might help
```
get_material_to_effect(): {"Material_001-material": "Material_001-effect", "Material_002-material": "Material_002-effect"}
get_effects(): {"Material_001-effect": Lambert(LambertEffect { emission: [0.1583735, 0.03047829, 0.0898435, 0.3749995], diffuse: Texture("sphere_jpg-sampler"), index_of_refraction: 1.45 }), "Material_002-effect": Lambert(LambertEffect { emission: [0.0, 0.0, 0.0, 1.0], diffuse: Texture("chips_jpg-sampler"), index_of_refraction: 1.45 })}
get_images(): {"chips_jpg": "chips.jpg", "sphere_jpg": "sphere.jpg"}
```

This is the output of a `.dae` file containing two objects textured in Blender 2.9


Linter caused a big diff so I opened https://github.com/PistonDevelopers/piston_collada/pull/45#issue-688781314 so that it makes this PR easier to read. Otherwise I can try and undo the non-essential changes in this PR.