### PR TITLE
Fix the failure of loading collada files on windows

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,6 +5,7 @@ use xml::Xml::{CharacterNode, ElementNode};
 pub fn parse_string_to_vector<T: FromStr>(string: &str) -> Vec<T> {
     string
         .trim()
+        .replace("\r\n", "\n")
         .split(&[' ', '\n'][..])
         .map(|s| s.parse().ok().expect("Error parsing array in COLLADA file"))
         .collect()


### PR DESCRIPTION
Hey! 
First of all I would like to thank you for making this absolutely wonderful library. The code is some of the cleanest I have seen in my life. 
I was having issues loading some collada files downloaded directly from mixamo using the library. I decided to find the source and noticed that it was because new lines were being read as \r\n while the code was expecting \n. I have added the 1 line patch in this PR. Please consider merging it.

Again, thank you a lot for making this absolutely amazing library!